### PR TITLE
Support strings in addition to interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ Read through the config file to understand the supported services and provide th
 
 Identification is a way to gather more information about a phone number including the country of origin, phone number type and more. This feature is supported by Ding and Vonage.
 
-Your identifiable record should implement `Roomies\Phonable\Contracts\PhoneIdentifiable` - `getIdentifiablePhoneNumber()` should return the phone number in E.164 format.
+```php
+// Return an instance of \Roomies\Phonable\Identification\IdentificationResult
+$result = Identification::get('+12125550000');
+```
+
+Alternatively you can pass an object that implements `Roomies\Phonable\Contracts\PhoneIdentifiable` - `getIdentifiablePhoneNumber()` should return the phone number in E.164 format.
 
 ```php
 use Roomies\Phonable\Facades\Identification;
@@ -44,7 +49,7 @@ class User implements PhoneIdentifiable
 }
 
 // Return an instance of \Roomies\Phonable\Identification\IdentificationResult
-$result = Identification::handle($user);
+$result = Identification::get($user);
 ```
 
 You can swap the driver out on the fly as necessary.
@@ -52,14 +57,24 @@ You can swap the driver out on the fly as necessary.
 ```php
 use Roomies\Phonable\Facades\Identification;
 
-Identification::driver('ding')->handle($user);
+Identification::driver('ding')->get($user);
 ```
 
 ## Verification
 
 Verification is a two-step process in sending a generated code to a phone number that then needs to be entered back into your app to complete the process. This ensures your user has timely access to the phone number provided. This feature is supported by Ding, Twilio, and Vonage.
 
-Your verifiable record should implement `Roomies\Phonable\Contracts\PhoneVerifiable` - `getVerifiablePhoneNumber()` should return the phone number in E.164 format and `getVerifiableSession()` should return the previously stored verification request ID.
+
+
+```php
+// Return an instance of \Roomies\Phonable\Verification\VerificationRequest
+$request = Verification::send('+12125550000');
+
+// Return an instance of \Roomies\Phonable\Verification\VerificationResult
+$result = Verification::verify($request->id, 'code');
+```
+
+Alternatively you can pass an object that implements `Roomies\Phonable\Contracts\PhoneVerifiable` - `getVerifiablePhoneNumber()` should return the phone number in E.164 format and `getVerifiableSession()` should return the previously stored verification request ID.
 
 ```php
 use Roomies\Phonable\Facades\Verification;

--- a/src/Contracts/IdentifiesPhoneNumbers.php
+++ b/src/Contracts/IdentifiesPhoneNumbers.php
@@ -9,5 +9,5 @@ interface IdentifiesPhoneNumbers
     /**
      * Fetch the identification for the given phone number.
      */
-    public function get(PhoneIdentifiable $identifiable): ?IdentificationResult;
+    public function get(string|PhoneIdentifiable $identifiable): ?IdentificationResult;
 }

--- a/src/Contracts/VerifiesPhoneNumbers.php
+++ b/src/Contracts/VerifiesPhoneNumbers.php
@@ -10,10 +10,10 @@ interface VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(PhoneVerifiable $verifiable): VerificationRequest;
+    public function send(string|PhoneVerifiable $verifiable): VerificationRequest;
 
     /**
      * Attempt to verify the phone number code.
      */
-    public function verify(PhoneVerifiable $verifiable, string $code): VerificationResult;
+    public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult;
 }

--- a/src/Identification/Ding.php
+++ b/src/Identification/Ding.php
@@ -31,9 +31,13 @@ class Ding implements IdentifiesPhoneNumbers
     /**
      * Fetch the identification for the given phone number.
      */
-    public function get(PhoneIdentifiable $identifiable): ?IdentificationResult
+    public function get(string|PhoneIdentifiable $identifiable): ?IdentificationResult
     {
-        $response = $this->client->get("/lookup/{$identifiable->getIdentifiablePhoneNumber()}");
+        $phoneNumber = $identifiable instanceof PhoneIdentifiable
+            ? $identifiable->getIdentifiablePhoneNumber()
+            : $identifiable;
+
+        $response = $this->client->get("/lookup/{$phoneNumber}");
 
         if ($response->failed()) {
             return null;

--- a/src/Identification/Vonage.php
+++ b/src/Identification/Vonage.php
@@ -23,15 +23,19 @@ class Vonage implements IdentifiesPhoneNumbers
     /**
      * Fetch the identification for the given phone number.
      */
-    public function get(PhoneIdentifiable $identifiable): ?IdentificationResult
+    public function get(string|PhoneIdentifiable $identifiable): ?IdentificationResult
     {
-        $method = Str::startsWith($identifiable->getIdentifiablePhoneNumber(), '+1')
+        $phoneNumber = $identifiable instanceof PhoneIdentifiable
+            ? $identifiable->getIdentifiablePhoneNumber()
+            : $identifiable;
+
+        $method = Str::startsWith($phoneNumber, '+1')
             ? 'standardCnam'
             : 'standard';
 
         try {
             $insight = $this->vonage->insights()
-                ->{$method}($identifiable->getIdentifiablePhoneNumber());
+                ->{$method}($phoneNumber);
         } catch (RequestException $exception) {
             return null;
         }

--- a/src/Testing/IdentificationFake.php
+++ b/src/Testing/IdentificationFake.php
@@ -35,8 +35,12 @@ class IdentificationFake implements Fake, IdentifiesPhoneNumbers
     /**
      * Fetch the identification for the given phone number.
      */
-    public function get(PhoneIdentifiable $identifiable): ?IdentificationResult
+    public function get(string|PhoneIdentifiable $identifiable): ?IdentificationResult
     {
-        return $this->responses[$identifiable->getIdentifiablePhoneNumber()] ?? null;
+        $phoneNumber = $identifiable instanceof PhoneIdentifiable
+            ? $identifiable->getIdentifiablePhoneNumber()
+            : $identifiable;
+
+        return $this->responses[$phoneNumber] ?? null;
     }
 }

--- a/src/Testing/VerificationFake.php
+++ b/src/Testing/VerificationFake.php
@@ -43,7 +43,7 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
     {
         $request = new VerificationRequest(
             id: Str::random(),
@@ -56,7 +56,7 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
     /**
      * Attempt to verify the phone number code.
      */
-    public function verify(PhoneVerifiable $verifiable, string $code): VerificationResult
+    public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
         return $this->responses[$verifiable->getVerifiablePhoneNumber()]
             ?? VerificationResult::NotFound;

--- a/src/Verification/Ding.php
+++ b/src/Verification/Ding.php
@@ -30,9 +30,9 @@ class Ding implements VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
     {
-        $phoneNumber = $verifiable->getVerifiablePhoneNumber();
+        $phoneNumber = $this->getPhoneNumber($verifiable);
 
         $response = $this->client
             ->post('/authentication', [
@@ -51,7 +51,7 @@ class Ding implements VerifiesPhoneNumbers
     /**
      * Attempt to complete a phone verification flow.
      */
-    public function verify(PhoneVerifiable $verifiable, string $code): VerificationResult
+    public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
         $response = $this->client
             ->post('/check', [
@@ -68,5 +68,15 @@ class Ding implements VerifiesPhoneNumbers
             'expired_auth' => VerificationResult::Expired,
             default => VerificationResult::Invalid,
         };
+    }
+
+    /**
+     * Get the phone number off a PhoneVerifiable instance if provided.
+     */
+    protected function getPhoneNumber(string|PhoneVerifiable $verifiable): ?string
+    {
+        return $verifiable instanceof PhoneVerifiable
+            ? $verifiable->getVerifiablePhoneNumber()
+            : $verifiable;
     }
 }

--- a/src/Verification/Ding.php
+++ b/src/Verification/Ding.php
@@ -53,10 +53,12 @@ class Ding implements VerifiesPhoneNumbers
      */
     public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
+        $session = $this->getVerifiableSession($verifiable);
+
         $response = $this->client
             ->post('/check', [
                 'customer_uuid' => $this->customerUuid,
-                'authentication_uuid' => $verifiable->getVerifiableSession(),
+                'authentication_uuid' => $session,
                 'check_code' => $code,
             ]);
 
@@ -77,6 +79,16 @@ class Ding implements VerifiesPhoneNumbers
     {
         return $verifiable instanceof PhoneVerifiable
             ? $verifiable->getVerifiablePhoneNumber()
+            : $verifiable;
+    }
+
+    /**
+     * Get the phone verification session off a PhoneVerifiable instance if provided.
+     */
+    protected function getVerifiableSession(string|PhoneVerifiable $verifiable): ?string
+    {
+        return $verifiable instanceof PhoneVerifiable
+            ? $verifiable->getVerifiableSession()
             : $verifiable;
     }
 }

--- a/src/Verification/Twilio.php
+++ b/src/Verification/Twilio.php
@@ -52,12 +52,12 @@ class Twilio implements VerifiesPhoneNumbers
      */
     public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
-        $phoneNumber = $this->getPhoneNumber($verifiable);
+        $session = $this->getVerifiableSession($verifiable);
 
         $response = $this->client
             ->asForm()
             ->post('/VerificationCheck', [
-                'VerificationSid' => $verifiable->getVerifiableSession(),
+                'VerificationSid' => $session,
                 'Code' => $code,
             ]);
 
@@ -79,6 +79,16 @@ class Twilio implements VerifiesPhoneNumbers
     {
         return $verifiable instanceof PhoneVerifiable
             ? $verifiable->getVerifiablePhoneNumber()
+            : $verifiable;
+    }
+
+    /**
+     * Get the phone verification session off a PhoneVerifiable instance if provided.
+     */
+    protected function getVerifiableSession(string|PhoneVerifiable $verifiable): ?string
+    {
+        return $verifiable instanceof PhoneVerifiable
+            ? $verifiable->getVerifiableSession()
             : $verifiable;
     }
 }

--- a/src/Verification/Twilio.php
+++ b/src/Verification/Twilio.php
@@ -30,9 +30,9 @@ class Twilio implements VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
     {
-        $phoneNumber = $verifiable->getVerifiablePhoneNumber();
+        $phoneNumber = $this->getPhoneNumber($verifiable);
 
         $response = $this->client
             ->asForm()
@@ -50,9 +50,9 @@ class Twilio implements VerifiesPhoneNumbers
     /**
      * Attempt to complete a phone verification flow.
      */
-    public function verify(PhoneVerifiable $verifiable, string $code): VerificationResult
+    public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
-        $phoneNumber = $verifiable->getVerifiablePhoneNumber();
+        $phoneNumber = $this->getPhoneNumber($verifiable);
 
         $response = $this->client
             ->asForm()
@@ -70,5 +70,15 @@ class Twilio implements VerifiesPhoneNumbers
             'pending' => VerificationResult::Invalid,
             'canceled' => VerificationResult::Expired,
         };
+    }
+
+    /**
+     * Get the phone number off a PhoneVerifiable instance if provided.
+     */
+    protected function getPhoneNumber(string|PhoneVerifiable $verifiable): ?string
+    {
+        return $verifiable instanceof PhoneVerifiable
+            ? $verifiable->getVerifiablePhoneNumber()
+            : $verifiable;
     }
 }

--- a/src/Verification/Vonage.php
+++ b/src/Verification/Vonage.php
@@ -30,9 +30,9 @@ class Vonage implements VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
     {
-        $phoneNumber = $verifiable->getVerifiablePhoneNumber();
+        $phoneNumber = $this->getPhoneNumber($verifiable);
 
         $response = $this->client
             ->post('/v2/verify', [
@@ -58,7 +58,7 @@ class Vonage implements VerifiesPhoneNumbers
     /**
      * Attempt to complete a phone verification flow.
      */
-    public function verify(PhoneVerifiable $verifiable, string $code): VerificationResult
+    public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
         $response = $this->client
             ->post("/v2/verify/{$verifiable->getVerifiableSession()}", [
@@ -78,5 +78,15 @@ class Vonage implements VerifiesPhoneNumbers
         }
 
         return VerificationResult::Successful;
+    }
+
+    /**
+     * Get the phone number off a PhoneVerifiable instance if provided.
+     */
+    protected function getPhoneNumber(string|PhoneVerifiable $verifiable): ?string
+    {
+        return $verifiable instanceof PhoneVerifiable
+            ? $verifiable->getVerifiablePhoneNumber()
+            : $verifiable;
     }
 }

--- a/src/Verification/Vonage.php
+++ b/src/Verification/Vonage.php
@@ -60,8 +60,10 @@ class Vonage implements VerifiesPhoneNumbers
      */
     public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
+        $session = $this->getVerifiableSession($verifiable);
+
         $response = $this->client
-            ->post("/v2/verify/{$verifiable->getVerifiableSession()}", [
+            ->post("/v2/verify/{$session}", [
                 'code' => $code,
             ]);
 
@@ -87,6 +89,16 @@ class Vonage implements VerifiesPhoneNumbers
     {
         return $verifiable instanceof PhoneVerifiable
             ? $verifiable->getVerifiablePhoneNumber()
+            : $verifiable;
+    }
+
+    /**
+     * Get the phone verification session off a PhoneVerifiable instance if provided.
+     */
+    protected function getVerifiableSession(string|PhoneVerifiable $verifiable): ?string
+    {
+        return $verifiable instanceof PhoneVerifiable
+            ? $verifiable->getVerifiableSession()
             : $verifiable;
     }
 }

--- a/tests/Identification/DingTest.php
+++ b/tests/Identification/DingTest.php
@@ -8,6 +8,23 @@ use Roomies\Phonable\Tests\TestCase;
 
 class DingTest extends TestCase
 {
+    public function test_it_handles_string()
+    {
+        Http::fake([
+            'api.ding.live/v1/lookup/+12125550000' => Http::response([
+                'carrier' => 'carrier_name',
+                'country_code' => 'carrier_country',
+                'line_type' => 'network_type',
+            ], 200, ['content-type' => 'application/json']),
+        ]);
+
+        $result = app(Ding::class)->get('+12125550000');
+
+        $this->assertEquals('carrier_name', $result->carrierName);
+        $this->assertEquals('carrier_country', $result->carrierCountry);
+        $this->assertEquals('network_type', $result->networkType);
+    }
+
     public function test_it_handle_us_number()
     {
         $identifiable = new Identifiable(

--- a/tests/Identification/VonageTest.php
+++ b/tests/Identification/VonageTest.php
@@ -12,6 +12,32 @@ use Vonage\Insights\StandardCnam;
 
 class VonageTest extends TestCase
 {
+    public function test_it_handles_string()
+    {
+        $phoneNumber = '+12125550000';
+
+        $standardCnam = new StandardCnam($phoneNumber);
+        $standardCnam->fromArray([
+            'current_carrier' => [
+                'name' => 'Verizon Wireless',
+                'country' => 'US',
+                'network_type' => 'mobile',
+            ],
+            'caller_name' => 'Thomas Clement',
+        ]);
+
+        $this->mockResponse(function ($insights) use ($phoneNumber, $standardCnam) {
+            $insights->shouldReceive('standardCnam')
+                ->with($phoneNumber)
+                ->andReturn($standardCnam);
+        });
+
+        $result = app(Vonage::class)->get($phoneNumber);
+
+        $this->assertEquals('Verizon Wireless', $result->carrierName);
+        $this->assertEquals('Thomas Clement', $result->callerName);
+    }
+
     public function test_it_handle_us_number()
     {
         $identifiable = new Identifiable(

--- a/tests/Verification/DingTest.php
+++ b/tests/Verification/DingTest.php
@@ -47,6 +47,19 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
+        $result = app(Ding::class)->verify('request-id', '1234');
+
+        $this->assertEquals(VerificationResult::Successful, $result);
+    }
+
+    public function test_verify_returns_for_valid_code_with_verifiable()
+    {
+        Http::fake([
+            'api.ding.live/v1/check' => Http::response([
+                'status' => 'valid',
+            ], 200),
+        ]);
+
         $verifiable = new Verifiable(sessionId: 'request-id');
 
         $result = app(Ding::class)->verify($verifiable, '1234');
@@ -62,9 +75,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = app(Ding::class)->verify($verifiable, '1234');
+        $result = app(Ding::class)->verify('request-id', '1234');
 
         $this->assertEquals(VerificationResult::Successful, $result);
     }
@@ -77,9 +88,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = app(Ding::class)->verify($verifiable, '1234');
+        $result = app(Ding::class)->verify('request-id', '1234');
 
         $this->assertEquals(VerificationResult::Expired, $result);
     }
@@ -92,9 +101,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = app(Ding::class)->verify($verifiable, '5678');
+        $result = app(Ding::class)->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::NotFound, $result);
     }
@@ -107,9 +114,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = app(Ding::class)->verify($verifiable, '5678');
+        $result = app(Ding::class)->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::Invalid, $result);
     }

--- a/tests/Verification/DingTest.php
+++ b/tests/Verification/DingTest.php
@@ -17,6 +17,20 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
+        $result = app(Ding::class)->send('+12125550000');
+
+        $this->assertEquals('abc-123', $result->id);
+        $this->assertEquals('+12125550000', $result->phoneNumber);
+    }
+
+    public function test_send_creates_verification_request_with_verifiable()
+    {
+        Http::fake([
+            'api.ding.live/v1/authentication' => Http::response([
+                'authentication_uuid' => 'abc-123',
+            ], 200),
+        ]);
+
         $verifiable = new Verifiable;
 
         $result = app(Ding::class)->send($verifiable);

--- a/tests/Verification/TwilioTest.php
+++ b/tests/Verification/TwilioTest.php
@@ -47,6 +47,19 @@ class TwilioTest extends TestCase
             ], 200),
         ]);
 
+        $result = $this->getTwilio()->verify('request-id', '1234');
+
+        $this->assertEquals(VerificationResult::Successful, $result);
+    }
+
+    public function test_verify_returns_for_valid_code_with_verifiable()
+    {
+        Http::fake([
+            'verify.twilio.com/v2/Services/service_sid/VerificationCheck' => Http::response([
+                'status' => 'approved',
+            ], 200),
+        ]);
+
         $verifiable = new Verifiable(sessionId: 'request-id');
 
         $result = $this->getTwilio()->verify($verifiable, '1234');
@@ -62,9 +75,7 @@ class TwilioTest extends TestCase
             ], 200),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = $this->getTwilio()->verify($verifiable, '1234');
+        $result = $this->getTwilio()->verify('request-id', '1234');
 
         $this->assertEquals(VerificationResult::Expired, $result);
     }
@@ -76,9 +87,7 @@ class TwilioTest extends TestCase
             ], 404),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = $this->getTwilio()->verify($verifiable, '5678');
+        $result = $this->getTwilio()->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::NotFound, $result);
     }
@@ -91,9 +100,7 @@ class TwilioTest extends TestCase
             ], 200),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = $this->getTwilio()->verify($verifiable, '5678');
+        $result = $this->getTwilio()->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::Invalid, $result);
     }

--- a/tests/Verification/TwilioTest.php
+++ b/tests/Verification/TwilioTest.php
@@ -17,6 +17,20 @@ class TwilioTest extends TestCase
             ], 200),
         ]);
 
+        $result = $this->getTwilio()->send('+12125550000');
+
+        $this->assertEquals('abc-123', $result->id);
+        $this->assertEquals('+12125550000', $result->phoneNumber);
+    }
+
+    public function test_send_creates_verification_request_with_verifiable()
+    {
+        Http::fake([
+            'verify.twilio.com/v2/Services/service_sid/Verifications' => Http::response([
+                'sid' => 'abc-123',
+            ], 200),
+        ]);
+
         $verifiable = new Verifiable;
 
         $result = $this->getTwilio()->send($verifiable);

--- a/tests/Verification/VonageTest.php
+++ b/tests/Verification/VonageTest.php
@@ -45,6 +45,17 @@ class VonageTest extends TestCase
             'api.nexmo.com/v2/verify/request-id' => Http::response([], 200),
         ]);
 
+        $result = app(Vonage::class)->verify('request-id', '1234');
+
+        $this->assertEquals(VerificationResult::Successful, $result);
+    }
+
+    public function test_verify_returns_for_valid_code_with_verifiable()
+    {
+        Http::fake([
+            'api.nexmo.com/v2/verify/request-id' => Http::response([], 200),
+        ]);
+
         $verifiable = new Verifiable(sessionId: 'request-id');
 
         $result = app(Vonage::class)->verify($verifiable, '1234');
@@ -58,9 +69,7 @@ class VonageTest extends TestCase
             'api.nexmo.com/v2/verify/request-id' => Http::response([], 410),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = app(Vonage::class)->verify($verifiable, '1234');
+        $result = app(Vonage::class)->verify('request-id', '1234');
 
         $this->assertEquals(VerificationResult::Expired, $result);
     }
@@ -71,9 +80,7 @@ class VonageTest extends TestCase
             'api.nexmo.com/v2/verify/request-id' => Http::response([], 404),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = app(Vonage::class)->verify($verifiable, '5678');
+        $result = app(Vonage::class)->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::NotFound, $result);
     }
@@ -84,9 +91,7 @@ class VonageTest extends TestCase
             'api.nexmo.com/v2/verify/request-id' => Http::response([], 400),
         ]);
 
-        $verifiable = new Verifiable(sessionId: 'request-id');
-
-        $result = app(Vonage::class)->verify($verifiable, '5678');
+        $result = app(Vonage::class)->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::Invalid, $result);
     }

--- a/tests/Verification/VonageTest.php
+++ b/tests/Verification/VonageTest.php
@@ -17,6 +17,20 @@ class VonageTest extends TestCase
             ], 200),
         ]);
 
+        $result = app(Vonage::class)->send('+12125550000');
+
+        $this->assertEquals('abc-123', $result->id);
+        $this->assertEquals('+12125550000', $result->phoneNumber);
+    }
+
+    public function test_send_creates_verification_request_with_verifiable()
+    {
+        Http::fake([
+            'api.nexmo.com/v2/verify' => Http::response([
+                'request_id' => 'abc-123',
+            ], 200),
+        ]);
+
         $verifiable = new Verifiable;
 
         $result = app(Vonage::class)->send($verifiable);


### PR DESCRIPTION
This expands on the identification/verification services to accept a standalone string in addition to an object that implements the required interface. This should make it easier to use when model records aren't involved.