### PR TITLE
Rename Ding to Prelude

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/roomies-com/phonable/test.yml?branch=main&label=tests&style=flat-square)](https://github.com/roomies-com/phonable/actions?query=workflow%3Atest+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/roomies/phonable.svg?style=flat-square)](https://packagist.org/packages/roomies/phonable)
 
-Roomies Phonable provides an abstraction layer to identify and verify phone numbers in your Laravel app. Phone verification can be used to help identify legitmate users of your app and also serve as a way to handle 2-factor authentication. Phonable provides implementations for a number of phone services including [Ding](https://ding.live), [Twilio](https://www.twilio.com), and [Vonage](https://vonage.com).
+Roomies Phonable provides an abstraction layer to identify and verify phone numbers in your Laravel app. Phone verification can be used to help identify legitmate users of your app and also serve as a way to handle 2-factor authentication. Phonable provides implementations for a number of phone services including [Prelude](https://prelude.so) (previously Ding), [Twilio](https://www.twilio.com), and [Vonage](https://vonage.com).
 
 ## Installation
 
@@ -24,7 +24,7 @@ Read through the config file to understand the supported services and provide th
 
 ## Identification
 
-Identification is a way to gather more information about a phone number including the country of origin, phone number type and more. This feature is supported by Ding and Vonage.
+Identification is a way to gather more information about a phone number including the country of origin, phone number type and more. This feature is supported by Prelude and Vonage.
 
 ```php
 // Return an instance of \Roomies\Phonable\Identification\IdentificationResult
@@ -57,12 +57,12 @@ You can swap the driver out on the fly as necessary.
 ```php
 use Roomies\Phonable\Facades\Identification;
 
-Identification::driver('ding')->get($user);
+Identification::driver('prelude')->get($user);
 ```
 
 ## Verification
 
-Verification is a two-step process in sending a generated code to a phone number that then needs to be entered back into your app to complete the process. This ensures your user has timely access to the phone number provided. This feature is supported by Ding, Twilio, and Vonage.
+Verification is a two-step process in sending a generated code to a phone number that then needs to be entered back into your app to complete the process. This ensures your user has timely access to the phone number provided. This feature is supported by Prelude, Twilio, and Vonage.
 
 
 
@@ -130,7 +130,7 @@ You can swap the driver out on the fly as necessary.
 ```php
 use Roomies\Phonable\Facades\Verification;
 
-Verification::driver('ding')->send($user);
+Verification::driver('prelude')->send($user);
 ```
 
 ## License

--- a/config/phonable.php
+++ b/config/phonable.php
@@ -10,11 +10,11 @@ return [
     | This option controls the default identification driver when using this
     | feature. You can swap this driver on the fly if required.
     |
-    | Supported drivers: "ding", "vonage"
+    | Supported drivers: "prelude", "vonage"
     |
     */
     'identification' => [
-        'default' => env('PHONE_IDENTIFICATION_SERVICE', 'ding'),
+        'default' => env('PHONE_IDENTIFICATION_SERVICE', 'prelude'),
     ],
 
     /*
@@ -25,11 +25,11 @@ return [
     | This option controls the default verification driver when using this
     | feature. You can swap this driver on the fly if required.
     |
-    | Supported drivers: "ding", "twilio", "vonage"
+    | Supported drivers: "prelude", "twilio", "vonage"
     |
     */
     'verification' => [
-        'default' => env('PHONE_VERIFICATION_SERVICE', 'ding'),
+        'default' => env('PHONE_VERIFICATION_SERVICE', 'prelude'),
     ],
 
     /*
@@ -40,14 +40,14 @@ return [
     | Here you can configure the required credentials and additional metadata
     | for each supported external phone service.
     |
-    | Supported drivers: "ding", "twilio", "vonage"
+    | Supported drivers: "prelude", "twilio", "vonage"
     |
     */
     'services' => [
 
-        'ding' => [
-            'key' => env('DING_KEY'),
-            'customer_uuid' => env('DING_CUSTOMER_UUID'),
+        'prelude' => [
+            'key' => env('PRELUDE_KEY'),
+            'customer_uuid' => env('PRELUDE_CUSTOMER_UUID'),
         ],
 
         'twilio' => [

--- a/src/Identification/Manager.php
+++ b/src/Identification/Manager.php
@@ -16,13 +16,13 @@ class Manager extends BaseManager
     }
 
     /**
-     * Create an instance of the Ding driver.
+     * Create an instance of the Prelude driver.
      */
-    public function createDingDriver(): Ding
+    public function createPreludeDriver(): Prelude
     {
-        return new Ding(
-            $this->config['phonable.services.ding.key'],
-            $this->config['phonable.services.ding.customer_uuid'],
+        return new Prelude(
+            $this->config['phonable.services.prelude.key'],
+            $this->config['phonable.services.prelude.customer_uuid'],
             $this->getContainer()->make('request')->ip(),
         );
     }

--- a/src/Identification/Prelude.php
+++ b/src/Identification/Prelude.php
@@ -8,7 +8,7 @@ use Roomies\Phonable\Contracts\IdentifiesPhoneNumbers;
 use Roomies\Phonable\Contracts\PhoneIdentifiable;
 use SensitiveParameter;
 
-class Ding implements IdentifiesPhoneNumbers
+class Prelude implements IdentifiesPhoneNumbers
 {
     /**
      * The authenticated HTTP client.
@@ -16,7 +16,7 @@ class Ding implements IdentifiesPhoneNumbers
     protected PendingRequest $client;
 
     /**
-     * Create a new Ding instance.
+     * Create a new Prelude instance.
      */
     public function __construct(
         #[SensitiveParameter] protected string $apiKey = '',

--- a/src/Verification/Manager.php
+++ b/src/Verification/Manager.php
@@ -15,13 +15,13 @@ class Manager extends BaseManager
     }
 
     /**
-     * Create an instance of the Ding driver.
+     * Create an instance of the Prelude driver.
      */
-    public function createDingDriver(): Ding
+    public function createPreludeDriver(): Prelude
     {
-        return new Ding(
-            $this->config['phonable.services.ding.key'],
-            $this->config['phonable.services.ding.customer_uuid'],
+        return new Prelude(
+            $this->config['phonable.services.prelude.key'],
+            $this->config['phonable.services.prelude.customer_uuid'],
             $this->getContainer()->make('request')->ip(),
         );
     }

--- a/src/Verification/Prelude.php
+++ b/src/Verification/Prelude.php
@@ -8,7 +8,7 @@ use Roomies\Phonable\Contracts\PhoneVerifiable;
 use Roomies\Phonable\Contracts\VerifiesPhoneNumbers;
 use SensitiveParameter;
 
-class Ding implements VerifiesPhoneNumbers
+class Prelude implements VerifiesPhoneNumbers
 {
     /**
      * The authenticated HTTP client.
@@ -16,7 +16,7 @@ class Ding implements VerifiesPhoneNumbers
     protected PendingRequest $client;
 
     /**
-     * Create a new Ding instance.
+     * Create a new Prelude instance.
      */
     public function __construct(
         #[SensitiveParameter] protected string $apiKey = '',

--- a/tests/Identification/Prelude.php
+++ b/tests/Identification/Prelude.php
@@ -3,10 +3,10 @@
 namespace Roomies\Phonable\Tests\Identification;
 
 use Illuminate\Support\Facades\Http;
-use Roomies\Phonable\Identification\Ding;
+use Roomies\Phonable\Identification\Prelude;
 use Roomies\Phonable\Tests\TestCase;
 
-class DingTest extends TestCase
+class PreludeTest extends TestCase
 {
     public function test_it_handles_string()
     {
@@ -18,7 +18,7 @@ class DingTest extends TestCase
             ], 200, ['content-type' => 'application/json']),
         ]);
 
-        $result = app(Ding::class)->get('+12125550000');
+        $result = app(Prelude::class)->get('+12125550000');
 
         $this->assertEquals('carrier_name', $result->carrierName);
         $this->assertEquals('carrier_country', $result->carrierCountry);
@@ -39,7 +39,7 @@ class DingTest extends TestCase
             ], 200, ['content-type' => 'application/json']),
         ]);
 
-        $result = app(Ding::class)->get($identifiable);
+        $result = app(Prelude::class)->get($identifiable);
 
         $this->assertEquals('carrier_name', $result->carrierName);
         $this->assertEquals('carrier_country', $result->carrierCountry);
@@ -54,7 +54,7 @@ class DingTest extends TestCase
             'api.ding.live/v1/lookup/+12125550000' => Http::response(null, 404),
         ]);
 
-        $result = app(Ding::class)->get($identifiable);
+        $result = app(Prelude::class)->get($identifiable);
 
         $this->assertNull($result);
     }

--- a/tests/Verification/Prelude.php
+++ b/tests/Verification/Prelude.php
@@ -4,10 +4,10 @@ namespace Roomies\Phonable\Tests\Verification;
 
 use Illuminate\Support\Facades\Http;
 use Roomies\Phonable\Tests\TestCase;
-use Roomies\Phonable\Verification\Ding;
+use Roomies\Phonable\Verification\Prelude;
 use Roomies\Phonable\Verification\VerificationResult;
 
-class DingTest extends TestCase
+class PreludeTest extends TestCase
 {
     public function test_send_creates_verification_request()
     {
@@ -17,7 +17,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $result = app(Ding::class)->send('+12125550000');
+        $result = app(Prelude::class)->send('+12125550000');
 
         $this->assertEquals('abc-123', $result->id);
         $this->assertEquals('+12125550000', $result->phoneNumber);
@@ -33,7 +33,7 @@ class DingTest extends TestCase
 
         $verifiable = new Verifiable;
 
-        $result = app(Ding::class)->send($verifiable);
+        $result = app(Prelude::class)->send($verifiable);
 
         $this->assertEquals('abc-123', $result->id);
         $this->assertEquals($verifiable->getVerifiablePhoneNumber(), $result->phoneNumber);
@@ -47,7 +47,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $result = app(Ding::class)->verify('request-id', '1234');
+        $result = app(Prelude::class)->verify('request-id', '1234');
 
         $this->assertEquals(VerificationResult::Successful, $result);
     }
@@ -62,7 +62,7 @@ class DingTest extends TestCase
 
         $verifiable = new Verifiable(sessionId: 'request-id');
 
-        $result = app(Ding::class)->verify($verifiable, '1234');
+        $result = app(Prelude::class)->verify($verifiable, '1234');
 
         $this->assertEquals(VerificationResult::Successful, $result);
     }
@@ -75,7 +75,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $result = app(Ding::class)->verify('request-id', '1234');
+        $result = app(Prelude::class)->verify('request-id', '1234');
 
         $this->assertEquals(VerificationResult::Successful, $result);
     }
@@ -88,7 +88,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $result = app(Ding::class)->verify('request-id', '1234');
+        $result = app(Prelude::class)->verify('request-id', '1234');
 
         $this->assertEquals(VerificationResult::Expired, $result);
     }
@@ -101,7 +101,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $result = app(Ding::class)->verify('request-id', '5678');
+        $result = app(Prelude::class)->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::NotFound, $result);
     }
@@ -114,7 +114,7 @@ class DingTest extends TestCase
             ], 200),
         ]);
 
-        $result = app(Ding::class)->verify('request-id', '5678');
+        $result = app(Prelude::class)->verify('request-id', '5678');
 
         $this->assertEquals(VerificationResult::Invalid, $result);
     }


### PR DESCRIPTION
Ding is now Prelude. 

The API's haven't changed yet, but this just updates the naming on our end.