### PR TITLE
Explore adopting MultipleInstanceManager

### DIFF
--- a/config/phonable.php
+++ b/config/phonable.php
@@ -4,33 +4,29 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Default Identification Driver
+    | Default Identification Service
     |--------------------------------------------------------------------------
     |
-    | This option controls the default identification driver when using this
-    | feature. You can swap this driver on the fly if required.
+    | This option controls the default identification service when using this
+    | feature. You can swap this service on the fly if required.
     |
-    | Supported drivers: "prelude", "vonage"
+    | Supported services: "prelude", "vonage"
     |
     */
-    'identification' => [
-        'default' => env('PHONE_IDENTIFICATION_SERVICE', 'prelude'),
-    ],
+    'identification_service' => env('PHONE_IDENTIFICATION_SERVICE', 'prelude'),
 
     /*
     |--------------------------------------------------------------------------
-    | Default Verification Driver
+    | Default Verification Service
     |--------------------------------------------------------------------------
     |
-    | This option controls the default verification driver when using this
-    | feature. You can swap this driver on the fly if required.
+    | This option controls the default verification service when using this
+    | feature. You can swap this service on the fly if required.
     |
-    | Supported drivers: "prelude", "twilio", "vonage"
+    | Supported services: "prelude", "twilio", "vonage"
     |
     */
-    'verification' => [
-        'default' => env('PHONE_VERIFICATION_SERVICE', 'prelude'),
-    ],
+    'verification_service' => env('PHONE_VERIFICATION_SERVICE', 'prelude'),
 
     /*
     |--------------------------------------------------------------------------
@@ -46,17 +42,20 @@ return [
     'services' => [
 
         'prelude' => [
+            'driver' => 'prelude',
             'key' => env('PRELUDE_KEY'),
             'customer_uuid' => env('PRELUDE_CUSTOMER_UUID'),
         ],
 
         'twilio' => [
+            'driver' => 'twilio',
             'account_id' => env('TWILIO_ACCOUNT_ID'),
             'auth_token' => env('TWILIO_AUTH_TOKEN'),
             'service_sid' => env('TWILIO_SERVICE_SID'),
         ],
 
         'vonage' => [
+            'driver' => 'vonage',
             // See https://github.com/laravel/vonage-notification-channel for Vonage configuration
         ],
 

--- a/src/Identification/Manager.php
+++ b/src/Identification/Manager.php
@@ -2,36 +2,55 @@
 
 namespace Roomies\Phonable\Identification;
 
-use Illuminate\Support\Manager as BaseManager;
+use Illuminate\Support\MultipleInstanceManager;
 use Vonage\Client;
 
-class Manager extends BaseManager
+class Manager extends MultipleInstanceManager
 {
+    /**
+     * The name of the default instance.
+     */
+    protected ?string $defaultInstance;
+
     /**
      * Get the default driver name.
      */
-    public function getDefaultDriver(): string
+    public function getDefaultInstance(): string
     {
-        return $this->config['phonable.identification.default'];
+        return $this->defaultInstance ?? $this->config['phonable.identification_service'];
+    }
+
+    /**
+     * Set the default instance name.
+     */
+    public function setDefaultInstance(string $name): void
+    {
+        $this->defaultInstance = $name;
+    }
+
+    /**
+     * Get the instance specific configuration.
+     */
+    public function getInstanceConfig(string $name): array
+    {
+        return config("phonable.services.{$name}");
     }
 
     /**
      * Create an instance of the Prelude driver.
      */
-    public function createPreludeDriver(): Prelude
+    public function createPreludeDriver(array $config): Prelude
     {
         return new Prelude(
-            $this->config['phonable.services.prelude.key'],
-            $this->config['phonable.services.prelude.customer_uuid'],
-            $this->getContainer()->make('request')->ip(),
+            $config['key'], $config['customer_uuid'], $this->app->make('request')->ip(),
         );
     }
 
     /**
      * Create an instance of the Vonage driver.
      */
-    public function createVonageDriver(): Vonage
+    public function createVonageDriver(array $config): Vonage
     {
-        return new Vonage($this->getContainer()->make(Client::class));
+        return new Vonage($this->app->make(Client::class));
     }
 }

--- a/src/Identification/Manager.php
+++ b/src/Identification/Manager.php
@@ -14,24 +14,32 @@ class Manager extends MultipleInstanceManager
 
     /**
      * Get the default driver name.
+     *
+     * @return string
      */
-    public function getDefaultInstance(): string
+    public function getDefaultInstance()
     {
         return $this->defaultInstance ?? $this->config['phonable.identification_service'];
     }
 
     /**
      * Set the default instance name.
+     *
+     * @param  string  $name
+     * @return void
      */
-    public function setDefaultInstance(string $name): void
+    public function setDefaultInstance($name)
     {
         $this->defaultInstance = $name;
     }
 
     /**
      * Get the instance specific configuration.
+     *
+     * @param  string  $name
+     * @return array
      */
-    public function getInstanceConfig(string $name): array
+    public function getInstanceConfig($name)
     {
         return config("phonable.services.{$name}");
     }

--- a/src/Identification/Manager.php
+++ b/src/Identification/Manager.php
@@ -19,7 +19,8 @@ class Manager extends MultipleInstanceManager
      */
     public function getDefaultInstance()
     {
-        return $this->defaultInstance ?? $this->config['phonable.identification_service'];
+        return $this->defaultInstance
+            ?? $this->app['config']->get('phonable.identification_service');
     }
 
     /**
@@ -41,7 +42,7 @@ class Manager extends MultipleInstanceManager
      */
     public function getInstanceConfig($name)
     {
-        return config("phonable.services.{$name}");
+        return $this->app['config']->get("phonable.services.{$name}");
     }
 
     /**
@@ -50,7 +51,7 @@ class Manager extends MultipleInstanceManager
     public function createPreludeDriver(array $config): Prelude
     {
         return new Prelude(
-            $config['key'], $config['customer_uuid'], $this->app->make('request')->ip(),
+            $config['key'], $config['customer_uuid'], $this->app['request']->ip(),
         );
     }
 

--- a/src/PhonableServiceProvider.php
+++ b/src/PhonableServiceProvider.php
@@ -17,12 +17,12 @@ class PhonableServiceProvider extends ServiceProvider
 
         $this->app->bind(
             abstract: 'phone-identification',
-            concrete: Identification\Manager::class
+            concrete: fn ($app) => new Identification\Manager($app),
         );
 
         $this->app->bind(
             abstract: 'phone-verification',
-            concrete: Verification\Manager::class
+            concrete: fn ($app) => new Verification\Manager($app),
         );
     }
 

--- a/src/Verification/Manager.php
+++ b/src/Verification/Manager.php
@@ -12,25 +12,33 @@ class Manager extends MultipleInstanceManager
     protected ?string $defaultInstance;
 
     /**
-     * Get the default driver name.
+     * Get the default instance name.
+     *
+     * @return string
      */
-    public function getDefaultInstance(): string
+    public function getDefaultInstance()
     {
         return $this->defaultInstance ?? $this->config['phonable.verification_service'];
     }
 
     /**
      * Set the default instance name.
+     *
+     * @param  string  $name
+     * @return void
      */
-    public function setDefaultInstance(string $name): void
+    public function setDefaultInstance($name)
     {
         $this->defaultInstance = $name;
     }
 
     /**
      * Get the instance specific configuration.
+     *
+     * @param  string  $name
+     * @return array
      */
-    public function getInstanceConfig(string $name): array
+    public function getInstanceConfig($name)
     {
         return config("phonable.services.{$name}");
     }

--- a/src/Verification/Manager.php
+++ b/src/Verification/Manager.php
@@ -2,50 +2,64 @@
 
 namespace Roomies\Phonable\Verification;
 
-use Illuminate\Support\Manager as BaseManager;
+use Illuminate\Support\MultipleInstanceManager;
 
-class Manager extends BaseManager
+class Manager extends MultipleInstanceManager
 {
+    /**
+     * The name of the default instance.
+     */
+    protected ?string $defaultInstance;
+
     /**
      * Get the default driver name.
      */
-    public function getDefaultDriver(): string
+    public function getDefaultInstance(): string
     {
-        return $this->config['phonable.verification.default'];
+        return $this->defaultInstance ?? $this->config['phonable.verification_service'];
+    }
+
+    /**
+     * Set the default instance name.
+     */
+    public function setDefaultInstance(string $name): void
+    {
+        $this->defaultInstance = $name;
+    }
+
+    /**
+     * Get the instance specific configuration.
+     */
+    public function getInstanceConfig(string $name): array
+    {
+        return config("phonable.services.{$name}");
     }
 
     /**
      * Create an instance of the Prelude driver.
      */
-    public function createPreludeDriver(): Prelude
+    public function createPreludeDriver(array $config): Prelude
     {
         return new Prelude(
-            $this->config['phonable.services.prelude.key'],
-            $this->config['phonable.services.prelude.customer_uuid'],
-            $this->getContainer()->make('request')->ip(),
+            $config['key'], $config['customer_uuid'], $this->app->make('request')->ip(),
         );
     }
 
     /**
      * Create an instance of the Twilio driver.
      */
-    public function createTwilioDriver(): Twilio
+    public function createTwilioDriver(array $config): Twilio
     {
         return new Twilio(
-            $this->config['phonable.services.twilio.account_sid'],
-            $this->config['phonable.services.twilio.auth_token'],
-            $this->config['phonable.services.twilio.service_sid']
+            $config['account_sid'], $config['auth_token'], $config['service_sid']
         );
     }
 
     /**
      * Create an instance of the Vonage driver.
      */
-    public function createVonageDriver(): Vonage
+    public function createVonageDriver(array $config): Vonage
     {
-        return new Vonage(
-            $this->config['phonable.services.vonage.key'],
-            $this->config['phonable.services.vonage.secret']
-        );
+        return new Vonage($config['key'], $config['secret']);
     }
 }

--- a/src/Verification/Manager.php
+++ b/src/Verification/Manager.php
@@ -18,7 +18,8 @@ class Manager extends MultipleInstanceManager
      */
     public function getDefaultInstance()
     {
-        return $this->defaultInstance ?? $this->config['phonable.verification_service'];
+        return $this->defaultInstance
+            ?? $this->app['config']->get('phonable.verification_service');
     }
 
     /**
@@ -40,7 +41,7 @@ class Manager extends MultipleInstanceManager
      */
     public function getInstanceConfig($name)
     {
-        return config("phonable.services.{$name}");
+        return $this->app['config']->get("phonable.services.{$name}");
     }
 
     /**
@@ -49,7 +50,7 @@ class Manager extends MultipleInstanceManager
     public function createPreludeDriver(array $config): Prelude
     {
         return new Prelude(
-            $config['key'], $config['customer_uuid'], $this->app->make('request')->ip(),
+            $config['key'], $config['customer_uuid'], $this->app['request']->ip(),
         );
     }
 


### PR DESCRIPTION
This explores replacing the base support manager we use for identifications and verifications with the newly-discovered `MultipleInstanceManager`. This allows you to define multiple services/connections using the same driver (for example, multiple Vonage connections with different credentials).

* The config key names of the default identification/verification services has changed but the environment variable that it uses remains the same.
* The `getDefaultInstance`/`setDefaultInstance` thing is a little weird... sort of expected that functionality for free.

Other than that, fairly straight forward.