### PR TITLE
Add VerificationMethod and fix blocked send statuses

### DIFF
--- a/src/Contracts/VerifiesPhoneNumbers.php
+++ b/src/Contracts/VerifiesPhoneNumbers.php
@@ -2,6 +2,7 @@
 
 namespace Roomies\Phonable\Contracts;
 
+use Roomies\Phonable\Verification\VerificationMethod;
 use Roomies\Phonable\Verification\VerificationRequest;
 use Roomies\Phonable\Verification\VerificationResult;
 
@@ -10,7 +11,7 @@ interface VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(string|PhoneVerifiable $verifiable): VerificationRequest;
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest;
 
     /**
      * Attempt to verify the phone number code.

--- a/src/Testing/VerificationFake.php
+++ b/src/Testing/VerificationFake.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Testing\Fakes\Fake;
 use PHPUnit\Framework\Assert as PHPUnit;
 use Roomies\Phonable\Contracts\PhoneVerifiable;
 use Roomies\Phonable\Contracts\VerifiesPhoneNumbers;
+use Roomies\Phonable\Verification\VerificationMethod;
 use Roomies\Phonable\Verification\VerificationRequest;
 use Roomies\Phonable\Verification\VerificationRequestStatus;
 use Roomies\Phonable\Verification\VerificationResult;
@@ -44,7 +45,7 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
     {
         $request = new VerificationRequest(
             id: Str::random(),

--- a/src/Verification/Prelude.php
+++ b/src/Verification/Prelude.php
@@ -31,7 +31,7 @@ class Prelude implements VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 
@@ -46,16 +46,15 @@ class Prelude implements VerifiesPhoneNumbers
                     'user_agent' => $this->userAgent,
                     'device_platform' => 'web',
                 ],
+                'options' => [
+                    'method' => $this->method($method),
+                ],
             ]);
-
-        $status = $this->isBlocked($response)
-            ? VerificationRequestStatus::Blocked
-            : VerificationRequestStatus::Successful;
 
         return new VerificationRequest(
             id: $response->json('id'),
             phoneNumber: $phoneNumber,
-            status: $status,
+            status: $this->status($response),
             raw: $response,
         );
     }
@@ -95,11 +94,31 @@ class Prelude implements VerifiesPhoneNumbers
     }
 
     /**
-     * Determine if the request was blocked for suspicious reasons.
+     * Map the verification method to the Prelude option.
      */
-    protected function isBlocked($response): bool
+    protected function method(VerificationMethod $method): string
     {
-        return $response->json('status') === 'blocked'
-            && in_array($response->json('reason'), ['in_block_list', 'suspicious']);
+        return match ($method) {
+            VerificationMethod::Voice => 'voice',
+            VerificationMethod::Text => 'message',
+            VerificationMethod::Automatic => 'auto',
+        };
+    }
+
+    /**
+     * Determine the status of the verification request.
+     */
+    protected function status($response): VerificationRequestStatus
+    {
+        if (! in_array($response->json('status'), ['blocked', 'shadow_blocked'])) {
+            return VerificationRequestStatus::Successful;
+        }
+
+        if ($response->json('status') === 'shadow_blocked'
+            || in_array($response->json('reason'), ['in_block_list', 'suspicious'])) {
+            return VerificationRequestStatus::Blocked;
+        }
+
+        return VerificationRequestStatus::Failed;
     }
 }

--- a/src/Verification/Twilio.php
+++ b/src/Verification/Twilio.php
@@ -30,7 +30,7 @@ class Twilio implements VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 
@@ -38,7 +38,7 @@ class Twilio implements VerifiesPhoneNumbers
             ->asForm()
             ->post('/Verifications', [
                 'To' => $phoneNumber,
-                'Channel' => 'sms',
+                'Channel' => $this->channel($method),
             ]);
 
         $status = match ($response->json('status')) {
@@ -76,6 +76,18 @@ class Twilio implements VerifiesPhoneNumbers
             'approved' => VerificationResult::Successful,
             'pending' => VerificationResult::Invalid,
             'canceled' => VerificationResult::Expired,
+        };
+    }
+
+    /**
+     * Map the verification method to the Twilio channel.
+     */
+    protected function channel(VerificationMethod $method): string
+    {
+        return match ($method) {
+            VerificationMethod::Voice => 'call',
+            VerificationMethod::Text => 'sms',
+            VerificationMethod::Automatic => 'auto',
         };
     }
 

--- a/src/Verification/VerificationMethod.php
+++ b/src/Verification/VerificationMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Roomies\Phonable\Verification;
+
+enum VerificationMethod
+{
+    case Automatic;
+
+    case Text;
+
+    case Voice;
+}

--- a/src/Verification/Vonage.php
+++ b/src/Verification/Vonage.php
@@ -30,7 +30,7 @@ class Vonage implements VerifiesPhoneNumbers
     /**
      * Send the phone number verification code.
      */
-    public function send(string|PhoneVerifiable $verifiable): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 
@@ -39,7 +39,7 @@ class Vonage implements VerifiesPhoneNumbers
                 'brand' => config('app.name'),
                 'workflow' => [
                     [
-                        'channel' => 'sms',
+                        'channel' => $this->channel($method),
                         'to' => $phoneNumber,
                     ],
                 ],
@@ -82,6 +82,14 @@ class Vonage implements VerifiesPhoneNumbers
         }
 
         return VerificationResult::Successful;
+    }
+
+    /**
+     * Map the verification method to the Vonage channel.
+     */
+    protected function channel(VerificationMethod $method): string
+    {
+        return $method === VerificationMethod::Voice ? 'voice' : 'sms';
     }
 
     /**

--- a/tests/Verification/PreludeTest.php
+++ b/tests/Verification/PreludeTest.php
@@ -5,6 +5,7 @@ namespace Roomies\Phonable\Tests\Verification;
 use Illuminate\Support\Facades\Http;
 use Roomies\Phonable\Tests\TestCase;
 use Roomies\Phonable\Verification\Prelude;
+use Roomies\Phonable\Verification\VerificationMethod;
 use Roomies\Phonable\Verification\VerificationRequestStatus;
 use Roomies\Phonable\Verification\VerificationResult;
 
@@ -61,6 +62,67 @@ class PreludeTest extends TestCase
         $this->assertEquals('abc-123', $result->id);
         $this->assertEquals($verifiable->getVerifiablePhoneNumber(), $result->phoneNumber);
         $this->assertEquals(VerificationRequestStatus::Blocked, $result->status);
+    }
+
+    public function test_send_returns_failed_for_undeliverable_number(): void
+    {
+        Http::fake([
+            'api.prelude.dev/v2/verification' => Http::response([
+                'id' => 'abc-123',
+                'status' => 'blocked',
+                'reason' => 'invalid_phone_number',
+            ], 200),
+        ]);
+
+        $result = app(Prelude::class)->send('+12125550000');
+
+        $this->assertEquals(VerificationRequestStatus::Failed, $result->status);
+    }
+
+    public function test_send_returns_blocked_when_shadow_blocked(): void
+    {
+        Http::fake([
+            'api.prelude.dev/v2/verification' => Http::response([
+                'id' => 'abc-123',
+                'status' => 'shadow_blocked',
+            ], 200),
+        ]);
+
+        $result = app(Prelude::class)->send('+12125550000');
+
+        $this->assertEquals(VerificationRequestStatus::Blocked, $result->status);
+    }
+
+    public function test_send_defaults_to_automatic_method(): void
+    {
+        Http::fake([
+            'api.prelude.dev/v2/verification' => Http::response([
+                'id' => 'abc-123',
+                'status' => 'success',
+            ], 200),
+        ]);
+
+        app(Prelude::class)->send('+12125550000');
+
+        Http::assertSent(function ($request) {
+            return $request['options']['method'] === 'auto';
+        });
+    }
+
+    public function test_send_requests_voice_method(): void
+    {
+        Http::fake([
+            'api.prelude.dev/v2/verification' => Http::response([
+                'id' => 'abc-123',
+                'status' => 'success',
+            ], 200),
+        ]);
+
+        app(Prelude::class)->send('+12125550000', method: VerificationMethod::Voice);
+
+        Http::assertSent(function ($request) {
+            return $request['options']['method'] === 'voice';
+        });
     }
 
     public function test_verify_returns_for_valid_code(): void

--- a/tests/Verification/TwilioTest.php
+++ b/tests/Verification/TwilioTest.php
@@ -5,6 +5,7 @@ namespace Roomies\Phonable\Tests\Verification;
 use Illuminate\Support\Facades\Http;
 use Roomies\Phonable\Tests\TestCase;
 use Roomies\Phonable\Verification\Twilio;
+use Roomies\Phonable\Verification\VerificationMethod;
 use Roomies\Phonable\Verification\VerificationRequestStatus;
 use Roomies\Phonable\Verification\VerificationResult;
 
@@ -60,6 +61,48 @@ class TwilioTest extends TestCase
         $this->assertEquals('abc-123', $result->id);
         $this->assertEquals($verifiable->getVerifiablePhoneNumber(), $result->phoneNumber);
         $this->assertEquals(VerificationRequestStatus::Failed, $result->status);
+    }
+
+    public function test_send_defaults_to_automatic_channel(): void
+    {
+        Http::fake([
+            'verify.twilio.com/v2/Services/service_sid/Verifications' => Http::response([
+                'sid' => 'abc-123',
+                'status' => 'pending',
+            ], 200),
+        ]);
+
+        $this->getTwilio()->send('+12125550000');
+
+        Http::assertSent(fn ($request) => $request['Channel'] === 'auto');
+    }
+
+    public function test_send_requests_text_channel(): void
+    {
+        Http::fake([
+            'verify.twilio.com/v2/Services/service_sid/Verifications' => Http::response([
+                'sid' => 'abc-123',
+                'status' => 'pending',
+            ], 200),
+        ]);
+
+        $this->getTwilio()->send('+12125550000', method: VerificationMethod::Text);
+
+        Http::assertSent(fn ($request) => $request['Channel'] === 'sms');
+    }
+
+    public function test_send_requests_voice_channel(): void
+    {
+        Http::fake([
+            'verify.twilio.com/v2/Services/service_sid/Verifications' => Http::response([
+                'sid' => 'abc-123',
+                'status' => 'pending',
+            ], 200),
+        ]);
+
+        $this->getTwilio()->send('+12125550000', method: VerificationMethod::Voice);
+
+        Http::assertSent(fn ($request) => $request['Channel'] === 'call');
     }
 
     public function test_verify_returns_for_valid_code(): void

--- a/tests/Verification/VonageTest.php
+++ b/tests/Verification/VonageTest.php
@@ -4,6 +4,7 @@ namespace Roomies\Phonable\Tests\Verification;
 
 use Illuminate\Support\Facades\Http;
 use Roomies\Phonable\Tests\TestCase;
+use Roomies\Phonable\Verification\VerificationMethod;
 use Roomies\Phonable\Verification\VerificationRequestStatus;
 use Roomies\Phonable\Verification\VerificationResult;
 use Roomies\Phonable\Verification\Vonage;
@@ -40,6 +41,32 @@ class VonageTest extends TestCase
         $this->assertEquals('abc-123', $result->id);
         $this->assertEquals($verifiable->getVerifiablePhoneNumber(), $result->phoneNumber);
         $this->assertEquals(VerificationRequestStatus::Successful, $result->status);
+    }
+
+    public function test_send_defaults_to_sms_channel(): void
+    {
+        Http::fake([
+            'api.nexmo.com/v2/verify' => Http::response([
+                'request_id' => 'abc-123',
+            ], 200),
+        ]);
+
+        app(Vonage::class)->send('+12125550000');
+
+        Http::assertSent(fn ($request) => $request['workflow'][0]['channel'] === 'sms');
+    }
+
+    public function test_send_requests_voice_channel(): void
+    {
+        Http::fake([
+            'api.nexmo.com/v2/verify' => Http::response([
+                'request_id' => 'abc-123',
+            ], 200),
+        ]);
+
+        app(Vonage::class)->send('+12125550000', method: VerificationMethod::Voice);
+
+        Http::assertSent(fn ($request) => $request['workflow'][0]['channel'] === 'voice');
     }
 
     public function test_verify_returns_for_valid_code(): void


### PR DESCRIPTION
## Summary

Two changes to phone verification, motivated by reducing avoidable customer-support contacts during phone verification.

### 1. A `VerificationMethod` enum for channel selection

`VerifiesPhoneNumbers::send()` gains an optional `VerificationMethod` argument (`Automatic`, `Text`, `Voice`), defaulting to `Automatic`. This lets a caller pick the channel per send — for example, falling back to a **voice call on a retry** when an SMS hasn't arrived.

Each driver maps the method natively:

| Method | Prelude `options.method` | Twilio `Channel` | Vonage `workflow.channel` |
|---|---|---|---|
| `Automatic` | `auto` | `auto` | `sms` |
| `Text` | `message` | `sms` | `sms` |
| `Voice` | `voice` | `call` | `voice` |

Usage:

```php
Verification::send($user);                                  // Automatic
Verification::send($user, method: VerificationMethod::Voice); // voice
```

> **Behavior change:** the Twilio driver's default channel moves from `sms` to `auto` (Silent Network Auth with SMS fallback). Prelude and Vonage defaults are unchanged in behavior.

### 2. `blocked` sends are no longer reported as `Successful`

Previously the Prelude driver only mapped `blocked` responses with reason `in_block_list`/`suspicious` to `Blocked`; every other blocked response fell through to `Successful`. That meant an **undeliverable number** (e.g. `invalid_phone_number`) was reported as a successful send, dropping the user into a wait-for-a-code-that-never-arrives loop.

Now:

- not `blocked`/`shadow_blocked` → `Successful`
- `shadow_blocked`, or `blocked` with `in_block_list`/`suspicious` → `Blocked` (fraud)
- any other `blocked` reason → `Failed` (so the caller can surface an error)

## Test plan

- `vendor/bin/phpunit` — 45 passing, including new Prelude tests for `Failed` (undeliverable), `Blocked` (shadow-blocked), and the voice/auto `options.method` payload.
- `vendor/bin/pint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)