### PR TITLE
Fix Vonage exception class rename in client-core 4.13.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laravel/vonage-notification-channel": "^3.2",
         "orchestra/testbench": "^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^12.0",
-        "vonage/client-core": "^4.1.0"
+        "vonage/client-core": "^4.13.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Identification/Vonage.php
+++ b/src/Identification/Vonage.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Str;
 use Roomies\Phonable\Contracts\IdentifiesPhoneNumbers;
 use Roomies\Phonable\Contracts\PhoneIdentifiable;
 use Vonage\Client;
-use Vonage\Client\Exception\Request as RequestException;
+use Vonage\Client\Exception\RequestException;
 use Vonage\Insights\Standard;
 use Vonage\Insights\StandardCnam;
 

--- a/tests/Identification/VonageTest.php
+++ b/tests/Identification/VonageTest.php
@@ -6,7 +6,7 @@ use Mockery;
 use Roomies\Phonable\Identification\Vonage;
 use Roomies\Phonable\Tests\TestCase;
 use Vonage\Client;
-use Vonage\Client\Exception\Request as RequestException;
+use Vonage\Client\Exception\RequestException;
 use Vonage\Insights\Standard;
 use Vonage\Insights\StandardCnam;
 


### PR DESCRIPTION
## Problem

CI was failing on the `prefer-stable` matrix cells (surfaced on PR #11, but unrelated to it) with:

```
Roomies\Phonable\Tests\Identification\VonageTest::test_it_handles_failure
Error: Class "Vonage\Client\Exception\Request" not found
```

`vonage/client-core` **4.13.0** (released 2026-03-25) renamed every exception class with **no back-compat alias** — `Vonage\Client\Exception\Request` → `RequestException` (and likewise `Conflict`, `NotFound`, `Server`, `Transport`, `Validation`, `Credentials`).

Because `composer.json` pinned `^4.1.0`, the lockfile resolved 4.12.0 (class still present, passes locally) while `prefer-stable` CI resolved 4.13.0 (class gone → fatal). This broke not just the test but the production driver too: `src/Identification/Vonage.php` catches the same class.

## Fix

- Point both the driver and its test at the new `RequestException` class name.
- Bump the constraint to `^4.13.0` and update `composer.lock` (`vonage/client-core` 4.12.0 → 4.13.0, `vonage/jwt` 0.5.1 → 0.6.0) so the lockfile and a fresh `prefer-stable` install resolve consistently.

## Verification

- `vendor/bin/phpunit` → OK (41 tests, 71 assertions)
- `vendor/bin/pint --test` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)