### PR TITLE
Handle string phone numbers in VerificationFake

### DIFF
--- a/src/Testing/VerificationFake.php
+++ b/src/Testing/VerificationFake.php
@@ -46,13 +46,15 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
      */
     public function send(string|PhoneVerifiable $verifiable): VerificationRequest
     {
+        $phoneNumber = $this->getPhoneNumber($verifiable);
+
         $request = new VerificationRequest(
             id: Str::random(),
-            phoneNumber: $verifiable->getVerifiablePhoneNumber(),
+            phoneNumber: $phoneNumber,
             status: VerificationRequestStatus::Successful,
         );
 
-        return $this->requests[$verifiable->getVerifiablePhoneNumber()] = $request;
+        return $this->requests[$phoneNumber] = $request;
     }
 
     /**
@@ -60,8 +62,18 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
      */
     public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
-        return $this->responses[$verifiable->getVerifiablePhoneNumber()]
+        return $this->responses[$this->getPhoneNumber($verifiable)]
             ?? VerificationResult::NotFound;
+    }
+
+    /**
+     * Get the phone number off a PhoneVerifiable instance if provided.
+     */
+    protected function getPhoneNumber(string|PhoneVerifiable $verifiable): string
+    {
+        return $verifiable instanceof PhoneVerifiable
+            ? $verifiable->getVerifiablePhoneNumber()
+            : $verifiable;
     }
 
     /**

--- a/tests/Testing/VerificationFakeTest.php
+++ b/tests/Testing/VerificationFakeTest.php
@@ -67,6 +67,26 @@ class VerificationFakeTest extends TestCase
         }
     }
 
+    public function test_send_accepts_a_string_phone_number(): void
+    {
+        $fake = new VerificationFake;
+
+        $request = $fake->send('+12125550000');
+
+        $this->assertEquals('+12125550000', $request->phoneNumber);
+    }
+
+    public function test_verify_accepts_a_string_phone_number(): void
+    {
+        $fake = new VerificationFake([
+            '+12125550000' => VerificationResult::Successful,
+        ]);
+
+        $result = $fake->verify('+12125550000', 1234);
+
+        $this->assertEquals(VerificationResult::Successful, $result);
+    }
+
     public function test_faking_successful_verification(): void
     {
         $fake = new VerificationFake([


### PR DESCRIPTION
## Problem

`VerificationFake::send()` and `verify()` are typed `string|PhoneVerifiable`, but both unconditionally called `$verifiable->getVerifiablePhoneNumber()`. Passing a plain string — which the contract and every real driver support — fataled with a "call to a member function on string" error, so the fake didn't faithfully stand in for the real drivers.

Flagged by Copilot's review on #11 (low-confidence/suppressed), verified as a real pre-existing bug. Kept out of #11 since it's unrelated to that PR's scope.

## Fix

Resolve the phone number through a `getPhoneNumber()` helper, mirroring the `Prelude`/`Twilio`/`Vonage` drivers, and use it in both `send()` and `verify()`.

## Verification

- Added `VerificationFakeTest` cases exercising the string path for `send()` and `verify()` (both fataled before this change).
- `vendor/bin/phpunit` → OK (43 tests, 73 assertions)
- `vendor/bin/pint --test` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)