### PR TITLE
Let VerificationFake script the send status

### DIFF
--- a/src/Testing/VerificationFake.php
+++ b/src/Testing/VerificationFake.php
@@ -49,10 +49,16 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 
+        $response = $this->responses[$phoneNumber] ?? null;
+
+        $status = $response instanceof VerificationRequestStatus
+            ? $response
+            : VerificationRequestStatus::Successful;
+
         $request = new VerificationRequest(
             id: Str::random(),
             phoneNumber: $phoneNumber,
-            status: VerificationRequestStatus::Successful,
+            status: $status,
         );
 
         return $this->requests[$phoneNumber] = $request;
@@ -63,8 +69,11 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
      */
     public function verify(string|PhoneVerifiable $verifiable, string $code): VerificationResult
     {
-        return $this->responses[$this->getPhoneNumber($verifiable)]
-            ?? VerificationResult::NotFound;
+        $response = $this->responses[$this->getPhoneNumber($verifiable)] ?? null;
+
+        return $response instanceof VerificationResult
+            ? $response
+            : VerificationResult::NotFound;
     }
 
     /**

--- a/tests/Testing/VerificationFakeTest.php
+++ b/tests/Testing/VerificationFakeTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\ExpectationFailedException;
 use Roomies\Phonable\Testing\VerificationFake;
 use Roomies\Phonable\Tests\TestCase;
 use Roomies\Phonable\Tests\Verification\Verifiable;
+use Roomies\Phonable\Verification\VerificationRequestStatus;
 use Roomies\Phonable\Verification\VerificationResult;
 
 class VerificationFakeTest extends TestCase
@@ -74,6 +75,26 @@ class VerificationFakeTest extends TestCase
         $request = $fake->send('+12125550000');
 
         $this->assertEquals('+12125550000', $request->phoneNumber);
+    }
+
+    public function test_send_returns_successful_status_by_default(): void
+    {
+        $fake = new VerificationFake;
+
+        $request = $fake->send('+12125550000');
+
+        $this->assertEquals(VerificationRequestStatus::Successful, $request->status);
+    }
+
+    public function test_send_can_be_faked_with_a_status(): void
+    {
+        $fake = new VerificationFake([
+            '+12125550000' => VerificationRequestStatus::Failed,
+        ]);
+
+        $request = $fake->send('+12125550000');
+
+        $this->assertEquals(VerificationRequestStatus::Failed, $request->status);
     }
 
     public function test_verify_accepts_a_string_phone_number(): void


### PR DESCRIPTION
## Summary

`VerificationFake::send()` always returned `VerificationRequestStatus::Successful`, so consumers couldn't write tests that exercise the `Failed` (undeliverable) or `Blocked` send branches.

The constructor's seed array now accepts a `VerificationRequestStatus` in addition to the existing `VerificationResult`, routing each by type:

```php
// script a SEND outcome (new)
Verification::fake(['+12125550000' => VerificationRequestStatus::Failed]);
$fake->send($user);   // → VerificationRequest with status Failed

// script a VERIFY outcome (unchanged)
Verification::fake(['+12125550000' => VerificationResult::Successful]);
$fake->verify($user, '1234');  // → Successful
```

`send()` reads a seeded `VerificationRequestStatus` (defaulting to `Successful`); `verify()` reads a seeded `VerificationResult` (defaulting to `NotFound`). Each ignores the other enum, so existing usage is unchanged.

## Test plan

- `vendor/bin/phpunit` — 54 passing, including new coverage for the default send status and a scripted `Failed` send.
- `vendor/bin/pint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)