### PR TITLE
Treat non-success Prelude responses as failed

### DIFF
--- a/src/Verification/Prelude.php
+++ b/src/Verification/Prelude.php
@@ -110,7 +110,7 @@ class Prelude implements VerifiesPhoneNumbers
      */
     protected function status($response): VerificationRequestStatus
     {
-        if (! in_array($response->json('status'), ['blocked', 'shadow_blocked'])) {
+        if (in_array($response->json('status'), ['success', 'retry'])) {
             return VerificationRequestStatus::Successful;
         }
 

--- a/tests/Verification/PreludeTest.php
+++ b/tests/Verification/PreludeTest.php
@@ -93,6 +93,33 @@ class PreludeTest extends TestCase
         $this->assertEquals(VerificationRequestStatus::Blocked, $result->status);
     }
 
+    public function test_send_treats_a_reused_verification_as_successful(): void
+    {
+        Http::fake([
+            'api.prelude.dev/v2/verification' => Http::response([
+                'id' => 'abc-123',
+                'status' => 'retry',
+            ], 200),
+        ]);
+
+        $result = app(Prelude::class)->send('+12125550000');
+
+        $this->assertEquals(VerificationRequestStatus::Successful, $result->status);
+    }
+
+    public function test_send_returns_failed_when_the_request_errors(): void
+    {
+        Http::fake([
+            'api.prelude.dev/v2/verification' => Http::response([
+                'message' => 'Something went wrong.',
+            ], 500),
+        ]);
+
+        $result = app(Prelude::class)->send('+12125550000');
+
+        $this->assertEquals(VerificationRequestStatus::Failed, $result->status);
+    }
+
     public function test_send_defaults_to_automatic_method(): void
     {
         Http::fake([


### PR DESCRIPTION
## Problem

`Prelude::status()` defaulted to `Successful` for any response whose `status` wasn't `blocked`/`shadow_blocked`. An actual HTTP error from Prelude (5xx, 429 rate-limit, auth failure, malformed request) has no `status` field, so it fell through to **`Successful`** — and callers happily moved the user on to enter a verification code that was never sent.

Note this only affected genuine request errors. An *undeliverable number* already comes back as HTTP 200 `status: blocked` / `reason: invalid_phone_number` and was (and still is) correctly mapped to `Failed`.

## Fix

Flip the success check to an allowlist: only an explicit `success` or `retry` maps to `Successful`. Everything else — request errors and unknown statuses — falls through to `Failed`. `retry` is Prelude's "a code was already sent recently, reusing it" status, which is a successful send from our side.

| Response | status / reason | Before | After |
|---|---|---|---|
| sent | `success` | Successful | Successful |
| reused | `retry` | Successful | Successful |
| suspicious | `blocked` / `suspicious` | Blocked | Blocked |
| undeliverable | `blocked` / `invalid_phone_number` | Failed | Failed |
| shadow | `shadow_blocked` | Blocked | Blocked |
| **HTTP 5xx / 429** | _none_ | **Successful 🐛** | **Failed ✅** |

## Tests

- Added `test_send_returns_failed_when_the_request_errors` (the bug) and `test_send_treats_a_reused_verification_as_successful` (pins `retry`).
- Full suite green: 56 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)