### PR TITLE
Add options argument to Verification::send()

### DIFF
--- a/src/Contracts/VerifiesPhoneNumbers.php
+++ b/src/Contracts/VerifiesPhoneNumbers.php
@@ -10,8 +10,10 @@ interface VerifiesPhoneNumbers
 {
     /**
      * Send the phone number verification code.
+     *
+     * @param  array<string, mixed>  $options
      */
-    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest;
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic, array $options = []): VerificationRequest;
 
     /**
      * Attempt to verify the phone number code.

--- a/src/Testing/VerificationFake.php
+++ b/src/Testing/VerificationFake.php
@@ -44,8 +44,10 @@ class VerificationFake implements Fake, VerifiesPhoneNumbers
 
     /**
      * Send the phone number verification code.
+     *
+     * @param  array<string, mixed>  $options
      */
-    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic, array $options = []): VerificationRequest
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 

--- a/src/Verification/Prelude.php
+++ b/src/Verification/Prelude.php
@@ -30,26 +30,33 @@ class Prelude implements VerifiesPhoneNumbers
 
     /**
      * Send the phone number verification code.
+     *
+     * @param  array<string, mixed>  $options
      */
-    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic, array $options = []): VerificationRequest
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 
-        $response = $this->client
-            ->post('/verification', [
-                'target' => [
-                    'type' => 'phone_number',
-                    'value' => $phoneNumber,
-                ],
-                'signals' => [
-                    'ip' => $this->ipAddress,
-                    'user_agent' => $this->userAgent,
-                    'device_platform' => 'web',
-                ],
-                'options' => [
-                    'method' => $this->method($method),
-                ],
-            ]);
+        $payload = [
+            'target' => [
+                'type' => 'phone_number',
+                'value' => $phoneNumber,
+            ],
+            'signals' => [
+                'ip' => $this->ipAddress,
+                'user_agent' => $this->userAgent,
+                'device_platform' => 'web',
+            ],
+            'options' => [
+                'method' => $this->method($method),
+            ],
+        ];
+
+        if (! empty($options['dispatch_id'])) {
+            $payload['dispatch_id'] = $options['dispatch_id'];
+        }
+
+        $response = $this->client->post('/verification', $payload);
 
         return new VerificationRequest(
             id: $response->json('id'),

--- a/src/Verification/Twilio.php
+++ b/src/Verification/Twilio.php
@@ -29,8 +29,10 @@ class Twilio implements VerifiesPhoneNumbers
 
     /**
      * Send the phone number verification code.
+     *
+     * @param  array<string, mixed>  $options
      */
-    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic, array $options = []): VerificationRequest
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 

--- a/src/Verification/Vonage.php
+++ b/src/Verification/Vonage.php
@@ -29,8 +29,10 @@ class Vonage implements VerifiesPhoneNumbers
 
     /**
      * Send the phone number verification code.
+     *
+     * @param  array<string, mixed>  $options
      */
-    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic): VerificationRequest
+    public function send(string|PhoneVerifiable $verifiable, VerificationMethod $method = VerificationMethod::Automatic, array $options = []): VerificationRequest
     {
         $phoneNumber = $this->getPhoneNumber($verifiable);
 

--- a/tests/Verification/PreludeTest.php
+++ b/tests/Verification/PreludeTest.php
@@ -152,6 +152,20 @@ class PreludeTest extends TestCase
         });
     }
 
+    public function test_send_includes_dispatch_id_when_provided(): void
+    {
+        Http::fake([
+            'api.prelude.dev/v2/verification' => Http::response([
+                'id' => 'abc-123',
+                'status' => 'success',
+            ], 200),
+        ]);
+
+        app(Prelude::class)->send('+12125550000', options: ['dispatch_id' => 'dispatch-xyz']);
+
+        Http::assertSent(fn ($request) => $request['dispatch_id'] === 'dispatch-xyz');
+    }
+
     public function test_verify_returns_for_valid_code(): void
     {
         Http::fake([


### PR DESCRIPTION
## Summary

Adds an optional `array $options = []` parameter to `send()` across the `VerifiesPhoneNumbers` contract and all drivers (`Prelude`, `Twilio`, `Vonage`, and `VerificationFake`).

The **Prelude** driver maps a `dispatch_id` option onto the top-level `dispatch_id` field of the create-verification request, forwarding the identifier produced by the front-end [JS Signals SDK](https://docs.prelude.so/introduction/frontend-sdks/js-signals) for anti-fraud / silent verification. Keys are mapped explicitly per driver rather than blind-merged into the payload, so the abstraction continues to own each provider's wire format. The other drivers accept and ignore `$options` for now.

```php
Verification::send($user, options: ['dispatch_id' => $dispatchId]);
```

## Why

The Prelude web SDK gathers browser signals on the phone-number capture page and returns a `dispatchId`. Passing it into the backend create-verification call links those signals to the verification. This adds the seam for callers to forward it.

## Tests

- Added `test_send_includes_dispatch_id_when_provided` to `PreludeTest`.
- Full suite green (57 tests), Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)